### PR TITLE
Tpm load additions

### DIFF
--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -90,7 +90,7 @@ int
 tpm2tss_ecc_setappdata(EC_KEY *key, TPM2_DATA *data);
 
 int
-tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle);
+tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle, ESYS_TR owner);
 
 #ifdef __cplusplus
 }

--- a/include/tpm2-tss-engine.h
+++ b/include/tpm2-tss-engine.h
@@ -32,6 +32,7 @@
 #define TPM2_TSS_ENGINE_H
 
 #include <openssl/engine.h>
+#include <tss2/tss2_esys.h>
 #include <tss2/tss2_tpm2_types.h>
 
 #ifdef __cplusplus
@@ -87,6 +88,9 @@ tpm2tss_ecc_getappdata(EC_KEY *key);
 
 int
 tpm2tss_ecc_setappdata(EC_KEY *key, TPM2_DATA *data);
+
+int
+tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle);
 
 #ifdef __cplusplus
 }

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -590,6 +590,17 @@ init_tpm_key (ESYS_CONTEXT **esys_ctx, ESYS_TR *keyHandle, TPM2_DATA *tpm2Data)
 }
 
 
+/** Initialize the ESYS TPM connection, load a key then evict the key
+ *
+ * Establish a connection with the TPM using ESYS libraries, create a primary
+ * key using the persistent handle, evict the key into persistent storage and
+ * return the result.
+ * @param tpm2Data The key data, owner auth and key auth to be used
+ * @param persKeyHandle The persistent handle of the key
+ * @param owner The handle of the keys owner
+ * @retval TSS2_RC_SUCCESS on success
+ * @retval TSS2_RCs according to the error
+ */
 int tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle, ESYS_TR owner)
 {
     TSS2_RC r = 1;

--- a/src/tpm2-tss-engine-common.c
+++ b/src/tpm2-tss-engine-common.c
@@ -590,7 +590,7 @@ init_tpm_key (ESYS_CONTEXT **esys_ctx, ESYS_TR *keyHandle, TPM2_DATA *tpm2Data)
 }
 
 
-int tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle)
+int tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle, ESYS_TR owner)
 {
     TSS2_RC r = 1;
     ESYS_TR transKeyHandle = ESYS_TR_NONE;
@@ -616,7 +616,7 @@ int tpm2tss_load_and_evict(TPM2_DATA *tpm2Data, ESYS_TR persKeyHandle)
         goto error;
     }
 
-    r = Esys_EvictControl(esys_ctx, ESYS_TR_RH_OWNER, transKeyHandle,
+    r = Esys_EvictControl(esys_ctx, owner, transKeyHandle,
                           ESYS_TR_PASSWORD, ESYS_TR_NONE, ESYS_TR_NONE,
                           persKeyHandle, &newKeyHandle);
 


### PR DESCRIPTION
These functions cannot be cleanly moved outside of the engine and logically belong here anyways. This allows enftun to perform the load and evict as easily as any other operation provided in the engine. 